### PR TITLE
Add environment variable for GCloud Credentials Volume

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -18,7 +18,9 @@
         }
     },
     "features": {
-        "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+        "ghcr.io/devcontainers/features/common-utils:2": {"configureZshAsDefaultShell": true},
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+        "ghcr.io/gcornejov/devex/zsh-p10k:0": {}
     },
     "remoteUser": "node",
     "updateContentCommand": "npm install -g @devcontainers/cli"

--- a/.zshrc
+++ b/.zshrc
@@ -78,7 +78,7 @@ ZSH_THEME="powerlevel10k/powerlevel10k"
 # Custom plugins may be added to $ZSH_CUSTOM/plugins/
 # Example format: plugins=(rails git textmate ruby lighthouse)
 # Add wisely, as too many plugins slow down shell startup.
-plugins=(git docker gcloud poetry zsh-autosuggestions zsh-syntax-highlighting fast-syntax-highlighting)
+plugins=(git docker gcloud poetry uv terraform zsh-autosuggestions zsh-syntax-highlighting fast-syntax-highlighting)
 
 source $ZSH/oh-my-zsh.sh
 
@@ -110,6 +110,8 @@ source $ZSH/oh-my-zsh.sh
 # Example aliases
 # alias zshconfig="mate ~/.zshrc"
 # alias ohmyzsh="mate ~/.oh-my-zsh"
+
+export GCLOUD_CREDS_VOLUME=$(docker volume ls -f dangling=false --format "{{.Name}}" | grep gcloud-cli)
 
 [ -d ./.venv ] && command -v poetry 2>&1 >/dev/null && eval $(poetry env activate)
 

--- a/features/src/zsh-p10k/NOTES.md
+++ b/features/src/zsh-p10k/NOTES.md
@@ -1,0 +1,6 @@
+## Changelog
+
+| Version | Notes                                                  |
+| ------- | ------------------------------------------------------ |
+| 0.1.1   | Add environment varaible for GCloud Credentials Volume |
+| 0.1.0   | Initial Version                                        |

--- a/features/src/zsh-p10k/devcontainer-feature.json
+++ b/features/src/zsh-p10k/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "zsh-p10k",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "name": "ZSH Powerlevel10k",
     "description": "Setup Powerlevel10k theme for ZSH shell",
     "documentationURL": "https://github.com/gcornejov/DevEX/blob/main/features/src/zsh-p10k/README.md",

--- a/features/test/zsh-p10k/test.sh
+++ b/features/test/zsh-p10k/test.sh
@@ -12,10 +12,6 @@ source dev-container-features-test-lib
 # Feature-specific tests
 # The 'check' command comes from the dev-container-features-test-lib. Syntax is...
 # check <LABEL> <cmd> [args...]
-# check "validate powerlevel10k theme files" $([ -d "$ZSH_CUSTOM/themes/powerlevel10k" ] && [ ! -z "$( ls -A "$ZSH_CUSTOM/themes/powerlevel10k" )" ]) || exit 1
-# check "validate powerlevel10k config file" $([ -f "$HOME/.p10k.zsh" ]) || exit 1
-# check "validate powerlevel10k theme setup" grep -q "powerlevel10k/powerlevel10k" $HOME/.zshrc
-
 check "validate powerlevel10k theme files" [ -d "$ZSH_CUSTOM/themes/powerlevel10k" ] && [ ! -z "$( ls -A "$ZSH_CUSTOM/themes/powerlevel10k" )" ] || exit 1
 check "validate powerlevel10k config file" [ -f "$HOME/.p10k.zsh" ] || exit 1
 check "validate powerlevel10k theme setup" grep -q "powerlevel10k/powerlevel10k" $HOME/.zshrc


### PR DESCRIPTION
Update zsh profile with a environment variable containing the current docker volume where the Google Cloud Credentials are stored.

Also added `uv` and `terraform` plugins 